### PR TITLE
Remove VSS availability checks from tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ Thumbs.db
 .coverage
 coverage.xml
 .aider*
+
+**/.claude/settings.local.json
+CLAUDE.md
+.claude/

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,4 +10,3 @@ markers =
     unit: marks tests as unit tests
     integration: marks tests as integration tests
     async_test: marks tests as asynchronous
-    requires_vss: marks tests that require DuckDB with VSS extension

--- a/src/common/db_setup.py
+++ b/src/common/db_setup.py
@@ -216,13 +216,14 @@ def ensure_duckdb_vss_extension(conn: Optional[duckdb.DuckDBPyConnection] = None
 
     try:
         # Install and load VSS extension
+        # Try to install the extension if it doesn't exist (will fail if already installed)
         try:
             conn.execute("INSTALL vss;")
             logger.info("DuckDB VSS extension installed")
-        except Exception as e:
-            # If extension is already installed, this will fail, but that's okay
-            logger.debug(f"VSS extension installation attempt: {str(e)}")
+        except Exception:
+            logger.info("VSS extension already installed")
 
+        # Load the VSS extension
         conn.execute("LOAD vss;")
         logger.info("DuckDB VSS extension loaded")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,7 +114,6 @@ def in_memory_duckdb_connection():
             # Use the connection for testing
             ...
     """
-    import duckdb
     from src.common.db_setup import ensure_duckdb_tables, ensure_duckdb_vss_extension
 
     # Create in-memory connection
@@ -124,33 +123,12 @@ def in_memory_duckdb_connection():
         # Use the same table creation functions as the main application
         ensure_duckdb_tables(conn)
 
-        # Try to set up VSS extension, but don't fail tests if it's not available
-        try:
-            ensure_duckdb_vss_extension(conn)
-        except Exception as e:
-            pytest.skip(f"DuckDB VSS extension not available: {e}")
+        # Set up VSS extension
+        ensure_duckdb_vss_extension(conn)
 
         yield conn
     finally:
         conn.close()
-
-
-@pytest.fixture(autouse=True)
-def skip_if_no_vss(request):
-    """Skip tests that require VSS if it's not available."""
-    if request.node.get_closest_marker("requires_vss"):
-        try:
-            # Create a test connection to see if VSS is available
-            conn = duckdb.connect(":memory:")
-            try:
-                conn.execute("INSTALL vss;")
-                conn.execute("LOAD vss;")
-            except Exception as e:
-                pytest.skip(f"Test requires DuckDB with VSS extension: {e}")
-            finally:
-                conn.close()
-        except Exception:
-            pytest.skip("Could not create test DuckDB connection")
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/integration/common/test_vector_indexer.py
+++ b/tests/integration/common/test_vector_indexer.py
@@ -7,7 +7,6 @@ from src.common.indexer import VectorIndexer
 
 @pytest.mark.integration
 @pytest.mark.async_test
-@pytest.mark.requires_vss
 async def test_vectorindexer_with_real_duckdb(in_memory_duckdb_connection):
     """Test the DuckDB implementation of VectorIndexer with a real in-memory database."""
     # Create VectorIndexer with the in-memory test connection

--- a/tests/integration/services/test_document_service.py
+++ b/tests/integration/services/test_document_service.py
@@ -15,7 +15,6 @@ from src.web_service.services.document_service import (
 
 @pytest.mark.integration
 @pytest.mark.async_test
-@pytest.mark.requires_vss
 async def test_search_docs_with_duckdb(in_memory_duckdb_connection):
     """Test searching documents with DuckDB backend."""
     # Create test data in the in-memory database
@@ -78,7 +77,6 @@ async def test_search_docs_with_duckdb(in_memory_duckdb_connection):
 
 @pytest.mark.integration
 @pytest.mark.async_test
-@pytest.mark.requires_vss
 async def test_list_doc_pages_with_duckdb(in_memory_duckdb_connection):
     """Test listing document pages with DuckDB backend."""
     # Insert test data directly into the pages table
@@ -111,7 +109,6 @@ async def test_list_doc_pages_with_duckdb(in_memory_duckdb_connection):
 
 @pytest.mark.integration
 @pytest.mark.async_test
-@pytest.mark.requires_vss
 async def test_get_doc_page_with_duckdb(in_memory_duckdb_connection):
     """Test retrieving a document page with DuckDB backend."""
     # Insert test data directly into the pages table
@@ -142,7 +139,6 @@ async def test_get_doc_page_with_duckdb(in_memory_duckdb_connection):
 
 @pytest.mark.integration
 @pytest.mark.async_test
-@pytest.mark.requires_vss
 async def test_list_tags_with_duckdb(in_memory_duckdb_connection):
     """Test listing unique tags with DuckDB backend."""
     # Insert test data directly into the pages table with different tags


### PR DESCRIPTION
- Remove VSS_AVAILABLE flag and skip_if_no_vss fixtures
- Make tests assume VSS is always available
- Update db_setup.py to handle VSS extension installation properly
- Remove requires_vss marker from pytest.ini
- Update .gitignore to exclude CLAUDE.md and .claude/