### PR TITLE
Database optimizations, BM25 full-text search support

### DIFF
--- a/.cursor/rules/code-style.mdc
+++ b/.cursor/rules/code-style.mdc
@@ -1,0 +1,8 @@
+---
+description:
+globs:
+alwaysApply: true
+---
+- Use Google-style docstrings
+- Always type-annotate variables and methods
+- After making all changes, run `ruff format` and `ruff check --fix`

--- a/.cursor/rules/refactors.mdc
+++ b/.cursor/rules/refactors.mdc
@@ -1,0 +1,8 @@
+---
+description: Refactoring and implementing new logic
+globs:
+alwaysApply: false
+---
+- Run tests after refactor/implementation is completed, ensuring they pass, and add news tests as necessary
+- To run the tests, do `pytest` (making sure that you are using `.venv/bin/python`)
+- When tests fail, adjust them according to the changes in code OR fix the code if it's a logic issue

--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -1,0 +1,9 @@
+---
+description: Writing tests or implementing new logic
+globs:
+alwaysApply: false
+---
+- Always write tests using functional pytest
+- Tests should always maintain or increase code coverage
+- Use parametrized testing whenever possible, instead of multiple test functions
+- Use snapshot tests to check for known/constant values

--- a/src/common/indexer.py
+++ b/src/common/indexer.py
@@ -7,7 +7,7 @@ from typing import Any
 import duckdb
 
 from src.common.config import DUCKDB_EMBEDDINGS_TABLE, VECTOR_SIZE
-from src.lib.database import Database
+from src.lib.database import DatabaseOperations
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -32,8 +32,8 @@ class VectorIndexer:
         if connection is not None:
             self.conn = connection
         else:
-            db = Database()
-            self.conn = db.connect()
+            db = DatabaseOperations()
+            self.conn = db.db.ensure_connection()
 
         # Ensure VSS extension is installed and loaded
         try:

--- a/src/common/indexer.py
+++ b/src/common/indexer.py
@@ -7,7 +7,7 @@ from typing import Any
 import duckdb
 
 from src.common.config import DUCKDB_EMBEDDINGS_TABLE, VECTOR_SIZE
-from src.lib.database import DatabaseOperations
+from src.lib.database import DuckDBConnectionManager  # Changed import
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -31,20 +31,28 @@ class VectorIndexer:
         self._own_connection = connection is None
         if connection is not None:
             self.conn = connection
+            # If connection is provided, assume VSS is loaded or handled by the provider.
+            # Alternatively, could attempt a load here too, but might be redundant.
+            try:
+                # Attempt to load VSS if an external connection is provided, just in case.
+                # This might be better handled by the provider of the connection.
+                self.conn.execute("LOAD vss;")
+                logger.debug("VSS extension loaded on provided connection (attempted).")
+            except Exception as e_load_vss:
+                logger.debug(
+                    f"Could not load VSS on provided connection (may already be loaded or unavailable): {e_load_vss!s}"
+                )
         else:
-            db = DatabaseOperations()
-            self.conn = db.db.ensure_connection()
+            # Create and own a new connection using DuckDBConnectionManager
+            conn_manager = DuckDBConnectionManager()
+            self.conn = (
+                conn_manager.connect()
+            )  # .connect() handles INSTALL and LOAD of extensions like VSS
+            logger.debug(
+                "Created and connected new DuckDB connection via DuckDBConnectionManager for VectorIndexer."
+            )
 
-        # Ensure VSS extension is installed and loaded
-        try:
-            self.conn.execute("INSTALL vss;")
-            logger.debug("VSS extension installed")
-        except Exception as e:
-            # If extension is already installed, this will fail, but that's okay
-            logger.debug(f"VSS extension installation attempt: {e!s}")
-
-        self.conn.execute("LOAD vss;")
-        logger.debug("VSS extension loaded")
+        # The explicit INSTALL and LOAD vss calls are removed as conn_manager.connect() handles them.
 
         self.table_name = table_name or DUCKDB_EMBEDDINGS_TABLE
         logger.debug(f"Initialized VectorIndexer with table={self.table_name}")

--- a/src/crawl_worker/main.py
+++ b/src/crawl_worker/main.py
@@ -5,7 +5,7 @@ from rq import Worker
 
 from src.common.config import REDIS_URI, check_config
 from src.common.logger import get_logger
-from src.lib.database import Database
+from src.lib.database import DatabaseOperations
 
 # Get logger for this module
 logger = get_logger(__name__)
@@ -26,13 +26,13 @@ def main() -> int:
     # Initialize databases with write access
     try:
         logger.info("Initializing databases for the crawl worker...")
-        db = Database(read_only=False)
-        db.initialize()
+        db = DatabaseOperations(read_only=False)
+        db.db.initialize()
         logger.info("Database initialization completed successfully")
 
         # Double-check that the document_embeddings table exists
         # Reuse the connection from db
-        conn = db.conn
+        conn = db.db.conn
         if conn is None:
             logger.error("Failed to get DuckDB connection")
             return 1
@@ -52,7 +52,7 @@ def main() -> int:
             return 1
         logger.info("Verified document_embeddings table exists")
 
-        db.close()
+        db.db.close()
     except Exception as e:
         logger.error(f"Database initialization failed: {e!s}")
         return 1

--- a/src/crawl_worker/tasks.py
+++ b/src/crawl_worker/tasks.py
@@ -12,6 +12,7 @@ from src.common.logger import get_logger
 from src.common.processor import process_page_batch
 from src.lib.crawler import crawl_url
 from src.lib.database import DatabaseOperations
+from src.lib.database.schema import CREATE_FTS_INDEX_SQL
 from src.lib.database.utils import serialize_tags
 
 # Get logger for this module
@@ -42,56 +43,63 @@ def create_job(
     logger.info(f"Creating new job {job_id} for URL: {url}, max pages: {max_pages}")
 
     # Create job record in DuckDB
-    db = DatabaseOperations()
+    db_ops = DatabaseOperations()
     now = datetime.datetime.now()
 
     try:
-        # Insert into DuckDB
-        logger.info(f"Inserting job {job_id} into DuckDB")
-        db.db.ensure_connection()
-        db.db.begin_transaction()
-        db.db.conn.execute(
-            """
-            INSERT INTO jobs (
-                job_id, start_url, status, pages_discovered, pages_crawled,
-                max_pages, tags, created_at, updated_at
+        with db_ops.db as conn_manager:  # Use DuckDBConnectionManager as context manager
+            actual_conn = conn_manager.conn
+            if not actual_conn:
+                raise RuntimeError("Failed to get DB connection for create_job")
+
+            logger.info(f"Inserting job {job_id} into DuckDB")
+            conn_manager.begin_transaction()
+            actual_conn.execute(
+                """
+                INSERT INTO jobs (
+                    job_id, start_url, status, pages_discovered, pages_crawled,
+                    max_pages, tags, created_at, updated_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    job_id,
+                    str(url),
+                    "pending",
+                    0,
+                    0,
+                    max_pages,
+                    serialize_tags(tags),
+                    now,
+                    now,
+                ),
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                job_id,
-                str(url),
-                "pending",
-                0,
-                0,
-                max_pages,
-                serialize_tags(tags),
-                now,
-                now,
-            ),
-        )
-        # Ensure the changes are written to disk
-        db.db.commit()
+            conn_manager.commit()
 
-        # Force a checkpoint to ensure changes are persisted
-        db.db.conn.execute("CHECKPOINT")
+            # Force a checkpoint to ensure changes are persisted
+            actual_conn.execute("CHECKPOINT")
 
-        # Verify the job was created by reading it back
-        job_record = db.db.conn.execute(
-            "SELECT job_id FROM jobs WHERE job_id = ?",
-            (job_id,),
-        ).fetchone()
-        if not job_record:
-            logger.error(f"Job {job_id} was not successfully created in the database!")
-            raise Exception(f"Failed to create job {job_id} in the database")
+            # Verify the job was created by reading it back
+            job_record = actual_conn.execute(
+                "SELECT job_id FROM jobs WHERE job_id = ?",
+                (job_id,),
+            ).fetchone()
+            if not job_record:
+                logger.error(f"Job {job_id} was not successfully created in the database!")
+                # Rollback if verification fails, though commit was done.
+                # This state is problematic. Ideally, verification is part of the transaction.
+                # For now, just log and raise.
+                # conn_manager.rollback() # Not strictly correct as commit was done
+                raise Exception(
+                    f"Failed to create job {job_id} in the database after insert/commit"
+                )
 
-        logger.info(f"Successfully created job {job_id} in DuckDB")
+            logger.info(f"Successfully created job {job_id} in DuckDB")
 
-        # Enqueue the crawl task
+        # Enqueue the crawl task (outside DB connection context)
         redis_conn = redis.from_url(REDIS_URI)
         queue = Queue("worker", connection=redis_conn)
 
-        # Enqueue the crawl task
         logger.info(f"Enqueueing crawl task for job {job_id}")
         queue.enqueue(
             "src.crawl_worker.tasks.perform_crawl",
@@ -101,15 +109,12 @@ def create_job(
             max_pages,
             job_timeout=600,
         )
-
         logger.info(f"Enqueued crawl task for job {job_id}")
-
         return job_id
     except Exception as e:
         logger.exception(f"Error creating job for URL {url}: {e!s}")
         raise
-    finally:
-        db.db.close()
+    # No 'finally db.db.close()' needed, context manager handles it.
 
 
 def perform_crawl(
@@ -136,16 +141,16 @@ def perform_crawl(
     logger.info(f"Starting crawl job {job_id} for URL: {url}, max pages: {max_pages}")
 
     # Update job status to running
-    with DatabaseOperations() as db:
-        db.update_job_status(job_id, "running")
+    db_ops_running = DatabaseOperations()
+    asyncio.run(db_ops_running.update_job_status(job_id, "running"))
 
     try:
         # Run the crawl and processing pipeline
         result = asyncio.run(_execute_pipeline(job_id, url, tags, max_pages))
 
         # Update job status to completed
-        with DatabaseOperations() as db:
-            db.update_job_status(job_id, "completed")
+        db_ops_completed = DatabaseOperations()
+        asyncio.run(db_ops_completed.update_job_status(job_id, "completed"))
 
         logger.info(f"Completed crawl job {job_id}: {result}")
         return result
@@ -154,8 +159,8 @@ def perform_crawl(
         logger.exception(f"Error in crawl job {job_id}: {e!s}")
 
         # Update job status to failed
-        with DatabaseOperations() as db:
-            db.update_job_status(job_id, "failed", error_message=str(e))
+        db_ops_failed = DatabaseOperations()
+        asyncio.run(db_ops_failed.update_job_status(job_id, "failed", error_message=str(e)))
 
         return {"job_id": job_id, "status": "failed", "error": str(e)}
 
@@ -181,13 +186,13 @@ async def _execute_pipeline(
     logger.info(f"Job {job_id}: Starting pipeline for URL: {url} with max_pages={max_pages}")
 
     # Update job status to indicate crawling has started
-    with DatabaseOperations() as db:
-        db.update_job_status(
-            job_id=job_id,
-            status="running",
-            pages_discovered=0,
-            pages_crawled=0,
-        )
+    db_ops_crawl_start = DatabaseOperations()
+    await db_ops_crawl_start.update_job_status(
+        job_id=job_id,
+        status="running",
+        pages_discovered=0,
+        pages_crawled=0,
+    )
 
     # Step 1: Crawl the URL
     logger.info(f"Job {job_id}: Beginning crawling phase from URL: {url}")
@@ -197,13 +202,13 @@ async def _execute_pipeline(
     logger.info(f"Job {job_id}: Crawl discovered {pages_discovered} pages")
 
     # Update job progress after crawl phase
-    with DatabaseOperations() as db:
-        db.update_job_status(
-            job_id=job_id,
-            status="running",
-            pages_discovered=pages_discovered,
-            pages_crawled=0,
-        )
+    db_ops_crawl_progress = DatabaseOperations()
+    await db_ops_crawl_progress.update_job_status(
+        job_id=job_id,
+        status="running",
+        pages_discovered=pages_discovered,
+        pages_crawled=0,
+    )
 
     # Step 2: Process the crawled pages
     if crawl_results:
@@ -222,26 +227,34 @@ async def _execute_pipeline(
         )
 
         # Final update before completing
-        with DatabaseOperations() as db:
-            db.update_job_status(
-                job_id=job_id,
-                status="running",
-                pages_discovered=pages_discovered,
-                pages_crawled=pages_crawled,
-            )
+        db_ops_process_complete = DatabaseOperations()
+        await db_ops_process_complete.update_job_status(
+            job_id=job_id,
+            status="running",
+            pages_discovered=pages_discovered,
+            pages_crawled=pages_crawled,
+        )
     else:
         logger.warning(f"Job {job_id}: No pages were discovered during crawl")
         pages_crawled = 0
 
         # Update status for empty crawl
-        with DatabaseOperations() as db:
-            db.update_job_status(
-                job_id=job_id,
-                status="running",
-                pages_discovered=0,
-                pages_crawled=0,
-                error_message="No pages were discovered during crawl",
-            )
+        db_ops_empty_crawl = DatabaseOperations()
+        await db_ops_empty_crawl.update_job_status(
+            job_id=job_id,
+            status="running",
+            pages_discovered=0,
+            pages_crawled=0,
+            error_message="No pages were discovered during crawl",
+        )
+
+    db_ops_fts = DatabaseOperations()
+    with db_ops_fts.db as conn_manager:
+        actual_conn = conn_manager.conn
+        if not actual_conn:
+            raise RuntimeError("Failed to get DB connection for create_job")
+
+        actual_conn.execute(CREATE_FTS_INDEX_SQL)
 
     # Return final status
     logger.info(
@@ -277,52 +290,76 @@ def delete_docs(
         f"Starting delete task {task_id} with filters: tags={tags}, domain={domain}, page_ids={page_ids}",
     )
 
-    # Get a database instance with write access
-    db = DatabaseOperations(read_only=False)
-    db.db.ensure_connection()
-    db.db.begin_transaction()
+    db_ops = DatabaseOperations()  # Instantiate, remove read_only
+    deleted_pages = 0
+    page_ids_to_delete = []
 
     try:
-        # Build the SQL where clause based on filters
-        conditions = []
-        params = []
+        with db_ops.db as conn_manager:  # Use DuckDBConnectionManager as context manager
+            actual_conn = conn_manager.conn
+            if not actual_conn:
+                raise RuntimeError("Failed to get DB connection for delete_docs")
 
-        if page_ids and len(page_ids) > 0:
-            placeholders = ", ".join(["?" for _ in page_ids])
-            conditions.append(f"id IN ({placeholders})")
-            params.extend(page_ids)
+            conn_manager.begin_transaction()
 
-        if domain:
-            conditions.append("domain LIKE ?")
-            params.append(f"%{domain}%")
+            # Build the SQL where clause based on filters
+            conditions = []
+            params = []
 
-        if tags and len(tags) > 0:
-            tag_conditions = []
-            for tag in tags:
-                # Format the tag for JSON contains - note we need quotes around the value
-                # First parameter is the haystack (tags), second is the needle (our tag)
-                tag_conditions.append(f"json_valid(tags) AND json_contains(tags, '\"{tag}\"')")
+            if page_ids and len(page_ids) > 0:
+                placeholders = ", ".join(["?" for _ in page_ids])
+                conditions.append(f"id IN ({placeholders})")
+                params.extend(page_ids)
 
-            conditions.append(f"({' OR '.join(tag_conditions)})")
+            if domain:
+                conditions.append("domain LIKE ?")
+                params.append(f"%{domain}%")
 
-        where_clause = " AND ".join(conditions) if conditions else "1=1"
+            if tags and len(tags) > 0:
+                tag_conditions = []
+                for tag in tags:
+                    tag_conditions.append(f"json_valid(tags) AND json_contains(tags, '\"{tag}\"')")
+                if tag_conditions:  # Ensure there are conditions before joining
+                    conditions.append(f"({' OR '.join(tag_conditions)})")
 
-        # Get the IDs of pages that will be deleted
-        query = f"SELECT id FROM pages WHERE {where_clause}"
-        logger.debug(f"Executing query to get page IDs: {query}")
-        results = db.db.conn.execute(query, params).fetchall()
-        page_ids_to_delete = [row[0] for row in results]
+            where_clause = (
+                " AND ".join(conditions) if conditions else "1=1"
+            )  # Avoid "WHERE " if no conditions
 
-        # Then delete from SQL database
-        delete_query = f"DELETE FROM pages WHERE {where_clause}"
-        logger.debug(f"Executing delete query: {delete_query}")
-        cursor = db.db.conn.execute(delete_query, params)
-        deleted_pages = cursor.rowcount
+            if not conditions:  # Safety: don't delete all if no filters provided
+                logger.warning("Delete_docs called with no filters. Aborting delete operation.")
+                conn_manager.rollback()  # Rollback the empty transaction
+                return {
+                    "task_id": task_id,
+                    "deleted_pages": 0,
+                    "page_ids": [],
+                    "message": "No filters provided, no documents deleted.",
+                }
 
-        # Commit the changes
-        db.db.commit()
+            # Get the IDs of pages that will be deleted
+            query = f"SELECT id FROM pages WHERE {where_clause}"
+            logger.debug(f"Executing query to get page IDs: {query} with params: {params}")
+            results = actual_conn.execute(query, params).fetchall()
+            page_ids_to_delete = [row[0] for row in results]
 
-        logger.info(f"Deleted {deleted_pages} pages ")
+            if not page_ids_to_delete:
+                logger.info(f"No pages found matching delete criteria for task {task_id}.")
+                conn_manager.commit()  # Commit (empty) transaction
+                return {
+                    "task_id": task_id,
+                    "deleted_pages": 0,
+                    "page_ids": [],
+                }
+
+            # Then delete from SQL database
+            # Re-using where_clause and params is fine
+            delete_query = f"DELETE FROM pages WHERE {where_clause}"
+            logger.debug(f"Executing delete query: {delete_query} with params: {params}")
+            cursor = actual_conn.execute(delete_query, params)
+            deleted_pages = cursor.rowcount if cursor else 0
+
+            conn_manager.commit()
+            logger.info(f"Deleted {deleted_pages} pages for task {task_id}")
 
         return {
             "task_id": task_id,
@@ -330,7 +367,13 @@ def delete_docs(
             "page_ids": page_ids_to_delete,
         }
     except Exception as e:
-        logger.error(f"Error deleting documents: {e!s}")
+        logger.exception(f"Error deleting documents for task {task_id}: {e!s}")
+        # Attempt to rollback if conn_manager was successfully entered and has an active transaction
+        if "conn_manager" in locals() and conn_manager.transaction_active:
+            try:
+                logger.info("Attempting rollback due to error in delete_docs.")
+                conn_manager.rollback()
+            except Exception as rb_err:
+                logger.error(f"Failed to rollback during error handling in delete_docs: {rb_err}")
         raise
-    finally:
-        db.db.close()
+    # No 'finally db.db.close()' needed, context manager handles it.

--- a/src/lib/database/__init__.py
+++ b/src/lib/database/__init__.py
@@ -3,8 +3,7 @@
 This package provides a modular approach to database management for the Doctor project,
 separating connection handling, high-level operations, schema definitions, and utilities.
 
-The main interface for database operations is the `DatabaseOperations` class, also aliased
-as `Database` for convenience and backward compatibility.
+The main interface for database operations is the `DatabaseOperations` class.
 """
 
 from .connection import DuckDBConnectionManager
@@ -16,13 +15,10 @@ from .schema import (
 )
 from .utils import deserialize_tags, serialize_tags
 
-Database = DatabaseOperations
-
 __all__ = [
     "CREATE_DOCUMENT_EMBEDDINGS_TABLE_SQL",
     "CREATE_JOBS_TABLE_SQL",
     "CREATE_PAGES_TABLE_SQL",
-    "Database",  # Alias for DatabaseOperations
     "DatabaseOperations",
     "DuckDBConnectionManager",
     "deserialize_tags",

--- a/src/lib/database/connection.py
+++ b/src/lib/database/connection.py
@@ -40,7 +40,13 @@ class DuckDBConnectionManager:
     """
 
     def __init__(self) -> None:
-        """Initialize the DuckDBConnectionManager."""
+        """Initialize the DuckDBConnectionManager.
+
+        Args:
+            None.
+        Returns:
+            None.
+        """
         self.conn: duckdb.DuckDBPyConnection | None = None
         self.transaction_active: bool = False
 
@@ -54,7 +60,8 @@ class DuckDBConnectionManager:
         Args:
             conn: The active DuckDB connection.
             ext_name: The name of the extension to load (e.g., 'fts', 'vss').
-
+        Returns:
+            None.
         """
         # Check if the extension is already loaded
         try:
@@ -97,23 +104,26 @@ class DuckDBConnectionManager:
             )
 
     def _load_extensions(self, conn: duckdb.DuckDBPyConnection) -> None:
-        """Install (if necessary) and loads required DuckDB extensions (FTS, VSS)."""
+        """Install (if necessary) and loads required DuckDB extensions (FTS, VSS).
+
+        Args:
+            conn: The active DuckDB connection.
+        Returns:
+            None.
+        """
         self._load_single_extension(conn, "fts")
         self._load_single_extension(conn, "vss")
 
     def connect(self) -> duckdb.DuckDBPyConnection:
         """Establish and return a DuckDB connection.
 
-        Ensures the data directory exists and loads necessary extensions (FTS, VSS)
-        upon successful connection. Retries connection on failure.
-
+        Args:
+            None.
         Returns:
             duckdb.DuckDBPyConnection: An active DuckDB connection object.
-
         Raises:
             IOError: For OS-level I/O errors during directory creation.
             duckdb.Error: For DuckDB-specific connection failures after retries.
-
         """
         data_dir_path = pathlib.Path(DATA_DIR)
         db_file_path = pathlib.Path(DUCKDB_PATH)
@@ -165,8 +175,10 @@ class DuckDBConnectionManager:
     def close(self) -> None:
         """Close the database connection if it is open.
 
-        Attempts to roll back any active transaction before closing.
-        Logs any errors during rollback or close but suppresses them.
+        Args:
+            None.
+        Returns:
+            None.
         """
         if self.conn:
             try:
@@ -206,9 +218,10 @@ class DuckDBConnectionManager:
     def ensure_connection(self) -> duckdb.DuckDBPyConnection:
         """Ensure an active database connection exists, creating one if necessary.
 
+        Args:
+            None.
         Returns:
             duckdb.DuckDBPyConnection: An active DuckDB connection object.
-
         """
         if self.conn is not None:
             try:
@@ -224,7 +237,13 @@ class DuckDBConnectionManager:
         return self.connect()
 
     def begin_transaction(self) -> None:
-        """Begin a database transaction if one is not already active."""
+        """Begin a database transaction if one is not already active.
+
+        Args:
+            None.
+        Returns:
+            None.
+        """
         if self.transaction_active:
             logger.warning("Transaction already active, not beginning a new one.")
             return
@@ -234,7 +253,13 @@ class DuckDBConnectionManager:
         logger.debug("Began new database transaction.")
 
     def commit(self) -> None:
-        """Commit the current active transaction."""
+        """Commit the current active transaction.
+
+        Args:
+            None.
+        Returns:
+            None.
+        """
         if not self.transaction_active:
             logger.warning("No active transaction to commit.")
             return
@@ -247,7 +272,13 @@ class DuckDBConnectionManager:
             self.transaction_active = False
 
     def rollback(self) -> None:
-        """Roll back the current active transaction."""
+        """Roll back the current active transaction.
+
+        Args:
+            None.
+        Returns:
+            None.
+        """
         if not self.transaction_active:
             logger.warning("No active transaction to rollback.")
             return
@@ -262,8 +293,10 @@ class DuckDBConnectionManager:
     def ensure_tables(self) -> None:
         """Ensure all required base tables (jobs, pages) and FTS setup exist.
 
-        Creates the 'jobs' and 'pages' tables.
-        Sets up direct FTS indexing on the 'pages' table.
+        Args:
+            None.
+        Returns:
+            None.
         """
         conn = self.ensure_connection()
         from .schema import CREATE_JOBS_TABLE_SQL, CREATE_PAGES_TABLE_SQL
@@ -278,7 +311,13 @@ class DuckDBConnectionManager:
             raise
 
     def _create_hnsw_index(self, conn: duckdb.DuckDBPyConnection) -> None:
-        """Create HNSW index on document_embeddings.embedding."""
+        """Create HNSW index on document_embeddings.embedding.
+
+        Args:
+            conn: The active DuckDB connection.
+        Returns:
+            None.
+        """
         try:
             index_exists = False
             try:
@@ -306,9 +345,10 @@ class DuckDBConnectionManager:
     def ensure_vss_extension(self) -> None:
         """Ensure VSS extension is functional and document_embeddings table exists with HNSW index.
 
-        Enables experimental HNSW persistence.
-        Creates the 'document_embeddings' table if it doesn't exist.
-        Creates an HNSW index on the 'embedding' column.
+        Args:
+            None.
+        Returns:
+            None.
         """
         conn = self.ensure_connection()
         from .schema import CREATE_DOCUMENT_EMBEDDINGS_TABLE_SQL
@@ -379,7 +419,10 @@ class DuckDBConnectionManager:
     def initialize(self) -> None:
         """Initialize the database: creates directory, tables, and extensions.
 
-        This is the main setup method to ensure the database is ready for use.
+        Args:
+            None.
+        Returns:
+            None.
         """
         logger.debug("Initializing DuckDBConnectionManager...")
         # The directory creation is handled by ensure_connection -> connect
@@ -396,7 +439,13 @@ class DuckDBConnectionManager:
         logger.debug("DuckDBConnectionManager initialization complete.")
 
     def __enter__(self) -> "DuckDBConnectionManager":
-        """Enter the runtime context related to this object. Ensures connection."""
+        """Enter the runtime context related to this object. Ensures connection.
+
+        Args:
+            None.
+        Returns:
+            DuckDBConnectionManager: The context manager instance.
+        """
         self.ensure_connection()
         return self
 
@@ -408,7 +457,12 @@ class DuckDBConnectionManager:
     ) -> None:
         """Exit the runtime context related to this object. Closes connection.
 
-        Rolls back active transaction if an exception occurred within the context.
+        Args:
+            exc_type: Exception type if raised in context, else None.
+            exc_val: Exception value if raised in context, else None.
+            exc_tb: Traceback if exception raised, else None.
+        Returns:
+            None.
         """
         if exc_type and self.transaction_active:
             exception_name = exc_type.__name__ if exc_type else "UnknownException"

--- a/src/lib/database/operations.py
+++ b/src/lib/database/operations.py
@@ -43,7 +43,13 @@ class DatabaseOperations:
     """
 
     def __init__(self) -> None:
-        """Initialize the DatabaseOperations instance."""
+        """Initialize the DatabaseOperations instance.
+
+        Args:
+            None.
+        Returns:
+            None.
+        """
         self.db: DuckDBConnectionManager = DuckDBConnectionManager()
         self._write_lock: asyncio.Lock = asyncio.Lock()
         # Initialize the database (ensures tables/extensions exist)
@@ -135,7 +141,17 @@ class DatabaseOperations:
         pages_crawled: int | None,
         error_message: str | None,
     ) -> tuple[str, list[Any]]:
-        """Build dynamic SQL query and parameters for updating a job."""
+        """Build dynamic SQL query and parameters for updating a job.
+
+        Args:
+            job_id: The ID of the job to update.
+            status: The new status of the job.
+            pages_discovered: Optional number of pages discovered.
+            pages_crawled: Optional number of pages crawled.
+            error_message: Optional error message if the job failed.
+        Returns:
+            tuple[str, list[Any]]: The SQL query and parameters for updating the job.
+        """
         query_parts = [UPDATE_JOB_STATUS_BASE_SQL]
         params: list[Any] = [
             status,
@@ -234,7 +250,17 @@ class DatabaseOperations:
                         logger.info(f"Job {job_id} successfully updated to {status}.")
 
     async def _checkpoint_internal_async(self) -> None:
-        """Internal method to force a database checkpoint. Assumes lock may be held."""
+        """Internal method to force a database checkpoint. Assumes lock may be held.
+
+        Args:
+            None.
+        Returns:
+            None.
+        Raises:
+            RuntimeError: If the database connection cannot be obtained.
+            duckdb.Error: For DuckDB specific errors.
+            Exception: For other unexpected errors during the checkpoint.
+        """
         logger.debug("Attempting to force database checkpoint (internal)...")
         # This method is called from within an existing write_lock context if called
         # after a successful job update. If called directly, it needs its own context.
@@ -257,9 +283,10 @@ class DatabaseOperations:
     async def checkpoint_async(self) -> None:
         """Force a database checkpoint to ensure changes are persisted.
 
-        This operation is typically called after critical updates, such as when
-        a job status changes to "completed" or "failed".
-        This is a public method and will acquire the write lock.
+        Args:
+            None.
+        Returns:
+            None.
         """
         logger.info("Attempting to force database checkpoint (public)...")
         async with self._write_lock:

--- a/src/lib/database/operations.py
+++ b/src/lib/database/operations.py
@@ -75,37 +75,33 @@ class DatabaseOperations:
             page_id: Optional ID for the page. If None, a UUID will be generated.
 
         Returns:
-            The ID of the stored page (either provided or generated).
+            str: The ID of the stored page (either provided or generated).
 
         Raises:
-            IOError: If an I/O error occurs during database operations.
             duckdb.Error: For DuckDB specific errors.
             RuntimeError: For other unexpected errors during the storage process.
-
         """
-        if tags is None:
-            tags = []
-        current_page_id: str = page_id if page_id is not None else str(uuid.uuid4())
-        domain: str = urlparse(url).netloc
+        page_id = page_id or str(uuid.uuid4())
+        domain = urlparse(url).netloc
+        tags = tags or []
 
-        logger.debug(
-            f"Storing page {current_page_id} from {url} with {len(text)} characters.",
-        )
+        logger.debug(f"Storing page {page_id} from {url}")
 
         async with self._write_lock:
-            with self.db as conn_manager:  # DuckDBConnectionManager is now a context manager
-                actual_conn = conn_manager.conn  # Get the actual DuckDBPyConnection
-                if not actual_conn:  # Should not happen if __enter__ works
-                    raise RuntimeError("Failed to obtain database connection from manager.")
+            with self.db as conn_manager:
+                conn = conn_manager.conn
+                if not conn:
+                    raise RuntimeError("Failed to obtain database connection")
+
                 try:
                     await asyncio.to_thread(conn_manager.begin_transaction)
                     from .utils import serialize_tags
 
                     await asyncio.to_thread(
-                        actual_conn.execute,
+                        conn.execute,
                         INSERT_PAGE_SQL,
                         (
-                            current_page_id,
+                            page_id,
                             url,
                             domain,
                             text,
@@ -115,23 +111,16 @@ class DatabaseOperations:
                         ),
                     )
                     await asyncio.to_thread(conn_manager.commit)
+                    logger.debug(f"Stored page {page_id}")
+                    return page_id
                 except duckdb.Error:
-                    logger.exception(
-                        f"DuckDB error storing page {current_page_id} for URL {url}",
-                    )
+                    logger.exception(f"DuckDB error storing page {page_id}")
                     await asyncio.to_thread(conn_manager.rollback)
-                    # The conn_manager handles its own connection's state during rollback
                     raise
-                except Exception as e_generic:  # pragma: no cover
-                    msg = f"Unexpected error storing page {current_page_id} for URL {url}"
-                    logger.exception(msg)
+                except Exception as e:
+                    logger.exception(f"Error storing page {page_id}: {e}")
                     await asyncio.to_thread(conn_manager.rollback)
-                    raise RuntimeError(msg) from e_generic
-                else:
-                    logger.debug(
-                        f"Successfully stored page {current_page_id} in database.",
-                    )
-                    return current_page_id
+                    raise RuntimeError(f"Failed to store page {page_id}") from e
 
     def _build_update_job_query(
         self,
@@ -149,23 +138,21 @@ class DatabaseOperations:
             pages_discovered: Optional number of pages discovered.
             pages_crawled: Optional number of pages crawled.
             error_message: Optional error message if the job failed.
+
         Returns:
             tuple[str, list[Any]]: The SQL query and parameters for updating the job.
         """
         query_parts = [UPDATE_JOB_STATUS_BASE_SQL]
-        params: list[Any] = [
-            status,
-            datetime.datetime.now(datetime.UTC),
-        ]
-        if pages_discovered is not None:
-            query_parts.append("pages_discovered = ?")
-            params.append(pages_discovered)
-        if pages_crawled is not None:
-            query_parts.append("pages_crawled = ?")
-            params.append(pages_crawled)
-        if error_message is not None:
-            query_parts.append("error_message = ?")
-            params.append(error_message)
+        params = [status, datetime.datetime.now(datetime.UTC)]
+
+        for field, value in [
+            ("pages_discovered", pages_discovered),
+            ("pages_crawled", pages_crawled),
+            ("error_message", error_message),
+        ]:
+            if value is not None:
+                query_parts.append(f"{field} = ?")
+                params.append(value)
 
         query = f"{', '.join(query_parts)} WHERE job_id = ?"
         params.append(job_id)
@@ -179,7 +166,7 @@ class DatabaseOperations:
         pages_crawled: int | None = None,
         error_message: str | None = None,
     ) -> None:
-        """Update the status and other metadata of a crawl job in the database.
+        """Update the status and other metadata of a crawl job.
 
         Args:
             job_id: The ID of the job to update.
@@ -188,96 +175,74 @@ class DatabaseOperations:
             pages_crawled: Optional number of pages crawled.
             error_message: Optional error message if the job failed.
 
+        Returns:
+            None.
+
         Raises:
-            IOError: If an I/O error occurs during database operations.
             duckdb.Error: For DuckDB specific errors.
             RuntimeError: For other unexpected errors during the update.
-
         """
-        logger.info(
-            f"Updating job {job_id}: status='{status}', discovered={pages_discovered}, "
-            f"crawled={pages_crawled}, error='{error_message is not None}'",
-        )
-        update_successful = False
+        logger.info(f"Updating job {job_id} to status '{status}'")
+
         async with self._write_lock:
-            with self.db as conn_manager:  # DuckDBConnectionManager is now a context manager
-                actual_conn = conn_manager.conn
-                if not actual_conn:
-                    raise RuntimeError("Failed to obtain database connection from manager.")
+            with self.db as conn_manager:
+                conn = conn_manager.conn
+                if not conn:
+                    raise RuntimeError("Failed to obtain database connection")
+
                 try:
                     await asyncio.to_thread(conn_manager.begin_transaction)
 
-                    query, params_tuple = self._build_update_job_query(
-                        job_id,
-                        status,
-                        pages_discovered,
-                        pages_crawled,
-                        error_message,
+                    query, params = self._build_update_job_query(
+                        job_id, status, pages_discovered, pages_crawled, error_message
                     )
 
-                    cursor = await asyncio.to_thread(actual_conn.execute, query, params_tuple)
+                    cursor = await asyncio.to_thread(conn.execute, query, params)
                     rows_affected = cursor.rowcount if cursor else 0
 
                     if rows_affected == 0:
-                        logger.warning(
-                            f"Job status update for {job_id} affected 0 rows. Job may not exist.",
-                        )
+                        logger.warning(f"Job {job_id} not found for update")
                     else:
-                        logger.debug(
-                            f"Job status update for {job_id} affected {rows_affected} rows.",
-                        )
-                        update_successful = True
+                        logger.debug(f"Updated job {job_id}, {rows_affected} rows affected")
+
                     await asyncio.to_thread(conn_manager.commit)
+
+                    if rows_affected > 0 and status in ["completed", "failed"]:
+                        await self._checkpoint_internal_async()
+                        logger.info(f"Job {job_id} updated to {status} and checkpointed")
+
                 except duckdb.Error:
-                    logger.exception(
-                        f"DuckDB error updating job {job_id} to status {status}",
-                    )
+                    logger.exception(f"DuckDB error updating job {job_id}")
                     await asyncio.to_thread(conn_manager.rollback)
                     raise
-                except Exception as e_generic:  # pragma: no cover
-                    msg = f"Unexpected error updating job {job_id} to status {status}"
-                    logger.exception(msg)
+                except Exception as e:
+                    logger.exception(f"Error updating job {job_id}: {e}")
                     await asyncio.to_thread(conn_manager.rollback)
-                    raise RuntimeError(msg) from e_generic
-                else:
-                    if update_successful and status in ["completed", "failed"]:
-                        # Call checkpoint_async which will handle its own connection context
-                        await self._checkpoint_internal_async()
-                        logger.info(
-                            f"Job {job_id} successfully updated to {status} and checkpointed.",
-                        )
-                    elif update_successful:
-                        logger.info(f"Job {job_id} successfully updated to {status}.")
+                    raise RuntimeError(f"Failed to update job {job_id}") from e
 
     async def _checkpoint_internal_async(self) -> None:
-        """Internal method to force a database checkpoint. Assumes lock may be held.
+        """Internal method to force a database checkpoint.
 
         Args:
             None.
+
         Returns:
             None.
+
         Raises:
             RuntimeError: If the database connection cannot be obtained.
-            duckdb.Error: For DuckDB specific errors.
-            Exception: For other unexpected errors during the checkpoint.
+            Exception: For unexpected errors during the checkpoint.
         """
-        logger.debug("Attempting to force database checkpoint (internal)...")
-        # This method is called from within an existing write_lock context if called
-        # after a successful job update. If called directly, it needs its own context.
-        # For simplicity, we'll assume the lock is managed by the caller or not strictly needed
-        # if this were to be public, but since it's an internal helper for now:
+        logger.debug("Executing database checkpoint")
         with self.db as conn_manager:
-            actual_conn = conn_manager.conn
-            if not actual_conn:
-                raise RuntimeError("Failed to obtain database connection for checkpoint.")
+            conn = conn_manager.conn
+            if not conn:
+                raise RuntimeError("Failed to obtain database connection for checkpoint")
             try:
-                await asyncio.to_thread(actual_conn.execute, CHECKPOINT_SQL)
-                logger.info("Database checkpoint successful (internal).")
-            except duckdb.Error as e:  # pragma: no cover
-                logger.exception(f"Failed to force database checkpoint due to DB error: {e}")
-                raise
-            except Exception as e:  # pragma: no cover
-                logger.exception(f"Unexpected error during database checkpoint: {e}")
+                await asyncio.to_thread(conn.execute, CHECKPOINT_SQL)
+                logger.debug("Database checkpoint successful")
+            except Exception as e:
+                logger.exception(f"Database checkpoint failed: {e}")
                 raise
 
     async def checkpoint_async(self) -> None:
@@ -285,9 +250,10 @@ class DatabaseOperations:
 
         Args:
             None.
+
         Returns:
             None.
         """
-        logger.info("Attempting to force database checkpoint (public)...")
+        logger.info("Forcing database checkpoint")
         async with self._write_lock:
             await self._checkpoint_internal_async()

--- a/src/lib/database/operations.py
+++ b/src/lib/database/operations.py
@@ -48,6 +48,7 @@ class DatabaseOperations:
         """
         self.db: DuckDBConnectionManager = DuckDBConnectionManager(read_only=read_only)
         self._write_lock: asyncio.Lock = asyncio.Lock()
+        self.db.initialize()  # Ensure tables and extensions are set up
 
     def __enter__(self) -> "DatabaseOperations":
         """Enter the context manager, ensuring a database connection.

--- a/src/lib/database/schema.py
+++ b/src/lib/database/schema.py
@@ -4,6 +4,7 @@
 from src.common.config import VECTOR_SIZE
 
 # Table creation SQL statements
+# These constants define the SQL for creating the main tables in the Doctor database.
 CREATE_JOBS_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS jobs (
     job_id VARCHAR PRIMARY KEY,
@@ -45,11 +46,13 @@ CREATE TABLE IF NOT EXISTS document_embeddings (
 """
 
 # Extension management SQL
+# These constants are used to manage DuckDB extensions.
 CHECK_EXTENSION_LOADED_SQL = "SELECT * FROM duckdb_loaded_extensions() WHERE name = '{0}';"
 INSTALL_EXTENSION_SQL = "INSTALL {0};"
 LOAD_EXTENSION_SQL = "LOAD {0};"
 
 # FTS (Full-Text Search) related SQL
+# These constants are used for managing FTS indexes and tables.
 CREATE_FTS_INDEX_SQL = "PRAGMA create_fts_index('pages', 'id', 'raw_text', overwrite=1);"
 CHECK_FTS_INDEXES_SQL = (
     "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'fts_idx_%'"
@@ -60,6 +63,7 @@ CHECK_FTS_MAIN_PAGES_TABLE_SQL = (
 DROP_FTS_MAIN_PAGES_TABLE_SQL = "DROP TABLE IF EXISTS fts_main_pages;"
 
 # HNSW (Vector Search) related SQL
+# These constants are used for managing HNSW vector search indexes.
 SET_HNSW_PERSISTENCE_SQL = "SET hnsw_enable_experimental_persistence = true;"
 CHECK_HNSW_INDEX_SQL = (
     "SELECT count(*) FROM duckdb_indexes() WHERE index_name = 'hnsw_index_on_embeddings'"
@@ -72,18 +76,22 @@ WITH (metric = 'cosine');
 """
 
 # VSS (Vector Similarity Search) verification SQL
+# These constants are used to verify VSS extension functionality.
 VSS_ARRAY_TO_STRING_TEST_SQL = "SELECT array_to_string([0.1, 0.2]::FLOAT[], ', ');"
 VSS_COSINE_SIMILARITY_TEST_SQL = "SELECT list_cosine_similarity([0.1,0.2],[0.2,0.3]);"
 
 # Table existence check SQL
+# Used to check if a table exists in the database.
 CHECK_TABLE_EXISTS_SQL = "SELECT count(*) FROM information_schema.tables WHERE table_name = '{0}'"
 
 # Transaction management SQL
+# Used for managing transactions and checkpoints.
 BEGIN_TRANSACTION_SQL = "BEGIN TRANSACTION"
 CHECKPOINT_SQL = "CHECKPOINT"
 TEST_CONNECTION_SQL = "SELECT 1"
 
 # DML (Data Manipulation Language) SQL
+# Used for inserting and updating data in tables.
 INSERT_PAGE_SQL = """
 INSERT INTO pages (id, url, domain, raw_text, crawl_date, tags, job_id)
 VALUES (?, ?, ?, ?, ?, ?, ?)

--- a/src/lib/database/schema.py
+++ b/src/lib/database/schema.py
@@ -4,7 +4,7 @@
 from src.common.config import VECTOR_SIZE
 
 CREATE_JOBS_TABLE_SQL = """
-CREATE OR REPLACE TABLE jobs (
+CREATE TABLE IF NOT EXISTS jobs (
     job_id VARCHAR PRIMARY KEY,
     start_url VARCHAR,
     status VARCHAR,
@@ -19,7 +19,7 @@ CREATE OR REPLACE TABLE jobs (
 """
 
 CREATE_PAGES_TABLE_SQL = """
-CREATE OR REPLACE TABLE pages (
+CREATE TABLE IF NOT EXISTS pages (
     id VARCHAR PRIMARY KEY,
     url VARCHAR,
     domain VARCHAR,
@@ -31,7 +31,7 @@ CREATE OR REPLACE TABLE pages (
 """
 
 CREATE_DOCUMENT_EMBEDDINGS_TABLE_SQL = f"""
-CREATE OR REPLACE TABLE document_embeddings (
+CREATE TABLE IF NOT EXISTS document_embeddings (
     id VARCHAR PRIMARY KEY,
     embedding FLOAT[{VECTOR_SIZE}] NOT NULL,
     text_chunk VARCHAR,

--- a/src/lib/database/schema.py
+++ b/src/lib/database/schema.py
@@ -50,7 +50,7 @@ INSTALL_EXTENSION_SQL = "INSTALL {0};"
 LOAD_EXTENSION_SQL = "LOAD {0};"
 
 # FTS (Full-Text Search) related SQL
-CREATE_FTS_INDEX_SQL = "PRAGMA create_fts_index('pages', 'id', 'raw_text');"
+CREATE_FTS_INDEX_SQL = "PRAGMA create_fts_index('pages', 'id', 'raw_text', overwrite=1);"
 CHECK_FTS_INDEXES_SQL = (
     "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'fts_idx_%'"
 )

--- a/src/lib/database/schema.py
+++ b/src/lib/database/schema.py
@@ -3,6 +3,7 @@
 
 from src.common.config import VECTOR_SIZE
 
+# Table creation SQL statements
 CREATE_JOBS_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS jobs (
     job_id VARCHAR PRIMARY KEY,
@@ -42,3 +43,51 @@ CREATE TABLE IF NOT EXISTS document_embeddings (
     job_id VARCHAR
 );
 """
+
+# Extension management SQL
+CHECK_EXTENSION_LOADED_SQL = "SELECT * FROM duckdb_loaded_extensions() WHERE name = '{0}';"
+INSTALL_EXTENSION_SQL = "INSTALL {0};"
+LOAD_EXTENSION_SQL = "LOAD {0};"
+
+# FTS (Full-Text Search) related SQL
+CREATE_FTS_INDEX_SQL = "PRAGMA create_fts_index('pages', 'id', 'raw_text');"
+CHECK_FTS_INDEXES_SQL = (
+    "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'fts_idx_%'"
+)
+CHECK_FTS_MAIN_PAGES_TABLE_SQL = (
+    "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'fts_main_pages'"
+)
+DROP_FTS_MAIN_PAGES_TABLE_SQL = "DROP TABLE IF EXISTS fts_main_pages;"
+
+# HNSW (Vector Search) related SQL
+SET_HNSW_PERSISTENCE_SQL = "SET hnsw_enable_experimental_persistence = true;"
+CHECK_HNSW_INDEX_SQL = (
+    "SELECT count(*) FROM duckdb_indexes() WHERE index_name = 'hnsw_index_on_embeddings'"
+)
+CREATE_HNSW_INDEX_SQL = """
+CREATE INDEX hnsw_index_on_embeddings
+ON document_embeddings
+USING HNSW (embedding)
+WITH (metric = 'cosine');
+"""
+
+# VSS (Vector Similarity Search) verification SQL
+VSS_ARRAY_TO_STRING_TEST_SQL = "SELECT array_to_string([0.1, 0.2]::FLOAT[], ', ');"
+VSS_COSINE_SIMILARITY_TEST_SQL = "SELECT list_cosine_similarity([0.1,0.2],[0.2,0.3]);"
+
+# Table existence check SQL
+CHECK_TABLE_EXISTS_SQL = "SELECT count(*) FROM information_schema.tables WHERE table_name = '{0}'"
+
+# Transaction management SQL
+BEGIN_TRANSACTION_SQL = "BEGIN TRANSACTION"
+CHECKPOINT_SQL = "CHECKPOINT"
+TEST_CONNECTION_SQL = "SELECT 1"
+
+# DML (Data Manipulation Language) SQL
+INSERT_PAGE_SQL = """
+INSERT INTO pages (id, url, domain, raw_text, crawl_date, tags, job_id)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+"""
+
+# Base for dynamic UPDATE job query
+UPDATE_JOB_STATUS_BASE_SQL = "UPDATE jobs SET status = ?, updated_at = ?"

--- a/src/lib/database/utils.py
+++ b/src/lib/database/utils.py
@@ -17,11 +17,8 @@ def serialize_tags(tags: list[str] | None) -> str:
 
     Args:
         tags: A list of tag strings, or None.
-
     Returns:
-        A JSON string representation of the tags list.
-        Returns an empty list '[]' if tags is None.
-
+        str: A JSON string representation of the tags list. Returns an empty list '[]' if tags is None.
     """
     if tags is None:
         return json.dumps([])
@@ -33,11 +30,8 @@ def deserialize_tags(tags_json: str | None) -> list[str]:
 
     Args:
         tags_json: The JSON string containing the tags, or None.
-
     Returns:
-        A list of tag strings. Returns an empty list if input is None, empty,
-        or invalid JSON.
-
+        list[str]: A list of tag strings. Returns an empty list if input is None, empty, or invalid JSON.
     """
     if not tags_json:
         return []

--- a/src/web_service/api/diagnostics.py
+++ b/src/web_service/api/diagnostics.py
@@ -5,7 +5,7 @@ Important: Should be disabled in production.
 from fastapi import APIRouter, HTTPException, Query
 
 from src.common.logger import get_logger
-from src.lib.database import Database
+from src.lib.database import DatabaseOperations
 from src.web_service.services.debug_bm25 import debug_bm25_search
 
 # Get logger for this module
@@ -32,8 +32,8 @@ async def debug_bm25_endpoint(
     logger.info(f"API: Running BM25 diagnostics with query: '{query}'")
 
     # Get a fresh connection for each request
-    db = Database(read_only=True)
-    conn = await db.connect_with_retry()
+    db = DatabaseOperations(read_only=True)
+    conn = db.db.ensure_connection()
 
     try:
         # Call the diagnostic function
@@ -43,4 +43,4 @@ async def debug_bm25_endpoint(
         logger.error(f"Error during BM25 diagnostics: {e!s}")
         raise HTTPException(status_code=500, detail=f"Diagnostic error: {e!s}")
     finally:
-        db.close()
+        db.db.close()

--- a/src/web_service/api/diagnostics.py
+++ b/src/web_service/api/diagnostics.py
@@ -15,32 +15,173 @@ logger = get_logger(__name__)
 router = APIRouter(tags=["diagnostics"])
 
 
-@router.get("/debug_bm25", operation_id="debug_bm25")
-async def debug_bm25_endpoint(
+@router.get("/bm25_diagnostics", operation_id="bm25_diagnostics")
+async def bm25_diagnostics_endpoint(
     query: str = Query("test", description="The search query to test with"),
+    initialize: bool = Query(
+        True, description="If true, attempt to initialize FTS if in write mode."
+    ),
 ):
-    """Diagnose BM25 search issues by executing tests and gathering debug information.
-    This endpoint is for development and debugging purposes only.
-
-    Args:
-        query: Search query to test
-
-    Returns:
-        dict: Diagnostic information
-
     """
-    logger.info(f"API: Running BM25 diagnostics with query: '{query}'")
+    Combined endpoint for DuckDB FTS initialization and diagnostics.
+    - Checks for the existence of the 'pages' table and 'raw_text' column before attempting FTS index creation.
+    - Always includes the full error message from FTS index creation in the response.
+    - Adds verbose logging and schema checks to the diagnostics output.
+    """
+    logger.info(
+        "API: Running combined BM25 diagnostics and initialization endpoint (DuckDB-specific)"
+    )
 
-    # Get a fresh connection for each request
-    db = DatabaseOperations(read_only=True)
+    db = DatabaseOperations(read_only=not initialize)
     conn = db.db.ensure_connection()
+    read_only = db.db.read_only
+    initialization_summary = {}
+    schema_info = {}
+
+    # Check for 'pages' table and 'raw_text' column existence
+    try:
+        tables = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+        table_names = [row[0] for row in tables]
+        schema_info["tables"] = table_names
+        pages_table_exists = "pages" in table_names
+        initialization_summary["pages_table_exists"] = pages_table_exists
+        if pages_table_exists:
+            columns = conn.execute("PRAGMA table_info('pages')").fetchall()
+            col_names = [row[1] for row in columns]
+            schema_info["pages_columns"] = col_names
+            initialization_summary["pages_columns"] = col_names
+            raw_text_exists = "raw_text" in col_names
+            initialization_summary["raw_text_column_exists"] = raw_text_exists
+        else:
+            initialization_summary["pages_columns"] = []
+            initialization_summary["raw_text_column_exists"] = False
+    except Exception as e_schema:
+        initialization_summary["schema_check_error"] = str(e_schema)
+        schema_info["schema_check_error"] = str(e_schema)
 
     try:
-        # Call the diagnostic function
-        results = await debug_bm25_search(conn, query)
-        return results
+        if initialize and not read_only:
+            logger.info("Attempting FTS initialization in write mode...")
+            # 1. Load FTS extension
+            try:
+                conn.execute("INSTALL fts;")
+                conn.execute("LOAD fts;")
+                initialization_summary["fts_extension_loaded"] = True
+            except Exception as e_fts:
+                logger.warning(f"FTS extension loading during initialization: {e_fts}")
+                initialization_summary["fts_extension_loaded"] = False
+                initialization_summary["fts_extension_error"] = str(e_fts)
+            # 2. Create FTS index (only if table and column exist)
+            if initialization_summary.get("pages_table_exists") and initialization_summary.get(
+                "raw_text_column_exists"
+            ):
+                try:
+                    conn.execute("PRAGMA create_fts_index('pages', 'id', 'raw_text');")
+                    initialization_summary["fts_index_created"] = True
+                    initialization_summary["fts_index_creation_error"] = None
+                except Exception as e_index:
+                    logger.warning(f"FTS index creation error: {e_index}")
+                    initialization_summary["fts_index_created"] = False
+                    initialization_summary["fts_index_creation_error"] = str(e_index)
+                    if "already exists" in str(e_index):
+                        initialization_summary["fts_index_exists"] = True
+            else:
+                initialization_summary["fts_index_created"] = False
+                initialization_summary["fts_index_creation_error"] = (
+                    "'pages' table or 'raw_text' column does not exist."
+                )
+            # 2b. Check for FTS index existence using DuckDB's sqlite_master and information_schema.tables
+            try:
+                fts_indexes = conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'fts_idx_%'"
+                ).fetchall()
+                initialization_summary["fts_indexes_sqlite_master"] = (
+                    [row[0] for row in fts_indexes] if fts_indexes else []
+                )
+                initialization_summary["fts_index_exists_sqlite_master"] = bool(fts_indexes)
+                fts_idx_tables = conn.execute(
+                    "SELECT table_name FROM information_schema.tables WHERE table_name LIKE 'fts_idx_%'"
+                ).fetchall()
+                initialization_summary["fts_indexes_information_schema"] = (
+                    [row[0] for row in fts_idx_tables] if fts_idx_tables else []
+                )
+                initialization_summary["fts_index_exists_information_schema"] = bool(fts_idx_tables)
+            except Exception as e_fts_idx:
+                initialization_summary["fts_index_check_error"] = str(e_fts_idx)
+            # 3. Drop legacy table
+            try:
+                table_exists_result = conn.execute(
+                    "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'fts_main_pages'"
+                ).fetchone()
+                table_exists = table_exists_result[0] > 0 if table_exists_result else False
+                if table_exists:
+                    conn.execute("DROP TABLE IF EXISTS fts_main_pages;")
+                    initialization_summary["legacy_fts_main_pages_dropped"] = True
+                else:
+                    initialization_summary["legacy_fts_main_pages_dropped"] = False
+            except Exception as e_drop:
+                initialization_summary["legacy_fts_main_pages_drop_error"] = str(e_drop)
+        else:
+            initialization_summary["initialization_skipped"] = True
+            initialization_summary["read_only_mode"] = read_only
+    except Exception as e:
+        logger.error(f"Error during initialization: {e}")
+        initialization_summary["initialization_error"] = str(e)
+
+    # Always run diagnostics
+    try:
+        diagnostics = await debug_bm25_search(conn, query)
+        # Add FTS index check and schema info to diagnostics as well
+        try:
+            fts_indexes_diag = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'fts_idx_%'"
+            ).fetchall()
+            diagnostics["fts_indexes_sqlite_master"] = (
+                [row[0] for row in fts_indexes_diag] if fts_indexes_diag else []
+            )
+            diagnostics["fts_index_exists_sqlite_master"] = bool(fts_indexes_diag)
+            fts_idx_tables_diag = conn.execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_name LIKE 'fts_idx_%'"
+            ).fetchall()
+            diagnostics["fts_indexes_information_schema"] = (
+                [row[0] for row in fts_idx_tables_diag] if fts_idx_tables_diag else []
+            )
+            diagnostics["fts_index_exists_information_schema"] = bool(fts_idx_tables_diag)
+            # Add schema info
+            diagnostics["schema_info"] = schema_info
+        except Exception as e_fts_idx_diag:
+            diagnostics["fts_index_check_error"] = str(e_fts_idx_diag)
+        # Remove BM25 function checks and errors from diagnostics if present
+        for k in list(diagnostics.keys()):
+            if "bm25" in k or "BM25" in k:
+                diagnostics.pop(k)
+        # Remove recommendations about BM25 function
+        recs = diagnostics.get("recommendations", [])
+        diagnostics["recommendations"] = [rec for rec in recs if "match_bm25 function" not in rec]
     except Exception as e:
         logger.error(f"Error during BM25 diagnostics: {e!s}")
         raise HTTPException(status_code=500, detail=f"Diagnostic error: {e!s}")
     finally:
         db.db.close()
+
+    # Compose response
+    response = {
+        "initialization": initialization_summary,
+        "diagnostics": diagnostics,
+    }
+    # Recommendations: only mention /bm25_diagnostics?initialize=true for FTS index creation if no FTS index is found
+    fts_index_exists = response["diagnostics"].get("fts_index_exists_sqlite_master") or response[
+        "diagnostics"
+    ].get("fts_index_exists_information_schema")
+    recs = diagnostics.get("recommendations", [])
+    new_recs = [
+        rec for rec in recs if "/initialize_bm25" not in rec and "match_bm25 function" not in rec
+    ]
+    if not fts_index_exists:
+        new_recs.append(
+            "No FTS indexes found. Run /bm25_diagnostics?initialize=true with a write connection."
+        )
+    response["recommendations"] = new_recs
+    if "status" in diagnostics:
+        response["status"] = diagnostics["status"]
+    return response

--- a/src/web_service/api/documents.py
+++ b/src/web_service/api/documents.py
@@ -10,7 +10,7 @@ from src.common.models import (
     ListTagsResponse,
     SearchDocsResponse,
 )
-from src.lib.database import Database
+from src.lib.database import DatabaseOperations
 from src.web_service.services.document_service import (
     get_doc_page,
     list_doc_pages,
@@ -52,8 +52,8 @@ async def search_docs_endpoint(
 
     try:
         # Get a fresh DuckDB connection
-        db = Database(read_only=True)
-        conn = await db.connect_with_retry()
+        db = DatabaseOperations(read_only=True)
+        conn = db.db.ensure_connection()
         try:
             # Call the service function
             response = await search_docs(conn, query, tags, max_results, return_full_document_text)
@@ -63,7 +63,7 @@ async def search_docs_endpoint(
             raise HTTPException(status_code=500, detail=f"Database error: {db_error!s}")
         finally:
             # Close DuckDB connection
-            db.close()
+            db.db.close()
     except Exception as e:
         logger.error(f"Error searching documents: {e!s}")
         raise HTTPException(status_code=500, detail=f"Search error: {e!s}")
@@ -87,8 +87,8 @@ async def list_doc_pages_endpoint(
     logger.info(f"API: Listing document pages (page={page}, tags={tags})")
 
     # Get a fresh connection for each request
-    db = Database(read_only=True)
-    conn = await db.connect_with_retry()
+    db = DatabaseOperations(read_only=True)
+    conn = db.db.ensure_connection()
 
     try:
         # Call the service function
@@ -98,7 +98,7 @@ async def list_doc_pages_endpoint(
         logger.error(f"Error listing document pages: {e!s}")
         raise HTTPException(status_code=500, detail=f"Database error: {e!s}")
     finally:
-        db.close()
+        db.db.close()
 
 
 @router.get("/get_doc_page", response_model=GetDocPageResponse, operation_id="get_doc_page")
@@ -124,8 +124,8 @@ async def get_doc_page_endpoint(
     logger.info(f"API: Retrieving document page {page_id} (lines {starting_line}-{ending_line})")
 
     # Get a fresh connection for each request
-    db = Database(read_only=True)
-    conn = await db.connect_with_retry()
+    db = DatabaseOperations(read_only=True)
+    conn = db.db.ensure_connection()
 
     try:
         # Call the service function
@@ -140,7 +140,7 @@ async def get_doc_page_endpoint(
         logger.error(f"Error retrieving document page {page_id}: {e!s}")
         raise HTTPException(status_code=500, detail=f"Database error: {e!s}")
     finally:
-        db.close()
+        db.db.close()
 
 
 @router.get("/list_tags", response_model=ListTagsResponse, operation_id="list_tags")
@@ -164,8 +164,8 @@ async def list_tags_endpoint(
     )
 
     # Get a fresh connection for each request
-    db = Database(read_only=True)
-    conn = await db.connect_with_retry()
+    db = DatabaseOperations(read_only=True)
+    conn = db.db.ensure_connection()
 
     try:
         # Call the service function
@@ -175,4 +175,4 @@ async def list_tags_endpoint(
         logger.error(f"Error listing document tags: {e!s}")
         raise HTTPException(status_code=500, detail=f"Database error: {e!s}")
     finally:
-        db.close()
+        db.db.close()

--- a/src/web_service/api/documents.py
+++ b/src/web_service/api/documents.py
@@ -50,23 +50,28 @@ async def search_docs_endpoint(
         f"API: Searching docs with query: '{query}', tags: {tags}, max_results: {max_results}, return_full_document_text: {return_full_document_text}",
     )
 
+    db_ops = DatabaseOperations()
     try:
-        # Get a fresh DuckDB connection
-        db = DatabaseOperations(read_only=True)
-        conn = db.db.ensure_connection()
-        try:
+        # Use DuckDBConnectionManager as a context manager
+        with db_ops.db as conn_manager:
+            actual_conn = conn_manager.conn
+            if not actual_conn:
+                logger.error("Failed to obtain database connection for search_docs.")
+                raise HTTPException(status_code=500, detail="Database connection error.")
             # Call the service function
-            response = await search_docs(conn, query, tags, max_results, return_full_document_text)
+            response = await search_docs(
+                actual_conn, query, tags, max_results, return_full_document_text
+            )
             return response
-        except Exception as db_error:
-            logger.error(f"Database error during search: {db_error!s}")
-            raise HTTPException(status_code=500, detail=f"Database error: {db_error!s}")
-        finally:
-            # Close DuckDB connection
-            db.db.close()
-    except Exception as e:
+    except HTTPException:  # Re-raise HTTP exceptions directly
+        raise
+    except (
+        Exception
+    ) as e:  # Catch other exceptions (like DB errors from service or connection issues)
         logger.error(f"Error searching documents: {e!s}")
+        # Log the specific error, but return a generic server error to the client
         raise HTTPException(status_code=500, detail=f"Search error: {e!s}")
+    # No finally block to close connection, context manager handles it.
 
 
 @router.get("/list_doc_pages", response_model=ListDocPagesResponse, operation_id="list_doc_pages")
@@ -86,19 +91,22 @@ async def list_doc_pages_endpoint(
     """
     logger.info(f"API: Listing document pages (page={page}, tags={tags})")
 
-    # Get a fresh connection for each request
-    db = DatabaseOperations(read_only=True)
-    conn = db.db.ensure_connection()
-
+    db_ops = DatabaseOperations()
     try:
-        # Call the service function
-        response = await list_doc_pages(conn, page, tags)
-        return response
+        with db_ops.db as conn_manager:
+            actual_conn = conn_manager.conn
+            if not actual_conn:
+                logger.error("Failed to obtain database connection for list_doc_pages.")
+                raise HTTPException(status_code=500, detail="Database connection error.")
+            # Call the service function
+            response = await list_doc_pages(actual_conn, page, tags)
+            return response
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error listing document pages: {e!s}")
         raise HTTPException(status_code=500, detail=f"Database error: {e!s}")
-    finally:
-        db.db.close()
+    # No finally block to close connection
 
 
 @router.get("/get_doc_page", response_model=GetDocPageResponse, operation_id="get_doc_page")
@@ -123,24 +131,25 @@ async def get_doc_page_endpoint(
     """
     logger.info(f"API: Retrieving document page {page_id} (lines {starting_line}-{ending_line})")
 
-    # Get a fresh connection for each request
-    db = DatabaseOperations(read_only=True)
-    conn = db.db.ensure_connection()
-
+    db_ops = DatabaseOperations()
     try:
-        # Call the service function
-        response = await get_doc_page(conn, page_id, starting_line, ending_line)
-        if response is None:
-            raise HTTPException(status_code=404, detail=f"Page {page_id} not found")
-        return response
+        with db_ops.db as conn_manager:
+            actual_conn = conn_manager.conn
+            if not actual_conn:
+                logger.error("Failed to obtain database connection for get_doc_page.")
+                raise HTTPException(status_code=500, detail="Database connection error.")
+            # Call the service function
+            response = await get_doc_page(actual_conn, page_id, starting_line, ending_line)
+            if response is None:
+                raise HTTPException(status_code=404, detail=f"Page {page_id} not found")
+            return response
     except HTTPException:
         # Re-raise HTTP exceptions as-is
         raise
     except Exception as e:
         logger.error(f"Error retrieving document page {page_id}: {e!s}")
         raise HTTPException(status_code=500, detail=f"Database error: {e!s}")
-    finally:
-        db.db.close()
+    # No finally block to close connection
 
 
 @router.get("/list_tags", response_model=ListTagsResponse, operation_id="list_tags")
@@ -163,16 +172,19 @@ async def list_tags_endpoint(
         f"API: Listing all unique document tags{' with filter: ' + search_substring if search_substring else ''}",
     )
 
-    # Get a fresh connection for each request
-    db = DatabaseOperations(read_only=True)
-    conn = db.db.ensure_connection()
-
+    db_ops = DatabaseOperations()
     try:
-        # Call the service function
-        response = await list_tags(conn, search_substring)
-        return response
+        with db_ops.db as conn_manager:
+            actual_conn = conn_manager.conn
+            if not actual_conn:
+                logger.error("Failed to obtain database connection for list_tags.")
+                raise HTTPException(status_code=500, detail="Database connection error.")
+            # Call the service function
+            response = await list_tags(actual_conn, search_substring)
+            return response
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error listing document tags: {e!s}")
         raise HTTPException(status_code=500, detail=f"Database error: {e!s}")
-    finally:
-        db.db.close()
+    # No finally block to close connection

--- a/src/web_service/api/jobs.py
+++ b/src/web_service/api/jobs.py
@@ -81,39 +81,46 @@ async def job_progress_endpoint(
     logger.info(f"Starting check loop for job {job_id} (max_attempts={max_attempts})")
     while attempts < max_attempts:
         attempts += 1
-        conn = None
+        db_ops = DatabaseOperations()  # Instantiate inside the loop
 
         try:
-            # Get a fresh read-only connection each time
-            db = DatabaseOperations(read_only=True)
-            conn = db.db.ensure_connection()
-            logger.info(f"Established fresh read-only connection to database (attempt {attempts})")
+            with db_ops.db as conn_manager:  # Use DuckDBConnectionManager as context manager
+                actual_conn = conn_manager.conn
+                if not actual_conn:
+                    # This case should ideally be handled by DuckDBConnectionManager.connect() raising an error
+                    logger.error(
+                        f"Attempt {attempts}: Failed to obtain DB connection from manager for job {job_id}."
+                    )
+                    if attempts >= max_attempts:
+                        raise HTTPException(
+                            status_code=500, detail="Database connection error after retries."
+                        )
+                    await asyncio.sleep(retry_delay)
+                    retry_delay *= 2
+                    continue  # To next attempt
 
-            # Call the service function
-            result = await get_job_progress(conn, job_id)
-
-            if not result:
-                # Job not found on this attempt
-                logger.warning(
-                    f"Job {job_id} not found (attempt {attempts}/{max_attempts}). Retrying in {retry_delay}s...",
+                logger.info(
+                    f"Established fresh connection to database (attempt {attempts}) for job {job_id}"
                 )
-                # Close connection before sleeping
-                if conn:
-                    db.db.close()
-                    conn = None  # Ensure we get a fresh one next iteration
 
-                # If this was the last attempt, break the loop to raise 404 outside
-                if attempts >= max_attempts:
-                    logger.warning(f"Job {job_id} not found after {max_attempts} attempts.")
-                    break  # Exit the while loop
+                # Call the service function
+                result = await get_job_progress(actual_conn, job_id)
 
-                # Wait before the next attempt
-                await asyncio.sleep(retry_delay)
-                retry_delay *= 2  # Exponential backoff
-                continue  # Go to next iteration of the while loop
+                if not result:
+                    # Job not found on this attempt
+                    logger.warning(
+                        f"Job {job_id} not found (attempt {attempts}/{max_attempts}). Retrying in {retry_delay}s...",
+                    )
+                    # Connection is closed by conn_manager context exit
+                    if attempts >= max_attempts:
+                        logger.warning(f"Job {job_id} not found after {max_attempts} attempts.")
+                        break  # Exit the while loop to raise 404
+                    await asyncio.sleep(retry_delay)
+                    retry_delay *= 2
+                    continue  # Go to next iteration of the while loop
 
-            # Job found, return the result
-            return result
+                # Job found, return the result
+                return result
 
         except HTTPException:
             # Re-raise HTTP exceptions as-is
@@ -121,43 +128,22 @@ async def job_progress_endpoint(
                 f"HTTPException occurred during attempt {attempts} for job {job_id}, re-raising.",
             )
             raise
-        except Exception as e:
-            # Log errors during attempts but don't necessarily stop retrying unless it's the last attempt
+        except Exception as e:  # Includes duckdb.Error if connect fails in conn_manager
             logger.error(
                 f"Error checking job progress (attempt {attempts}) for job {job_id}: {e!s}",
             )
             if attempts < max_attempts:
                 logger.info(f"Non-fatal error on attempt {attempts}, will retry after delay.")
-                # Clean up potentially broken connection before retrying
-                if conn:
-                    try:
-                        db.db.close()
-                        conn = None
-                    except Exception as close_err:
-                        logger.warning(
-                            f"Error closing connection during error handling: {close_err}",
-                        )
-                await asyncio.sleep(retry_delay)  # Wait before retry on error too
+                # Connection (if opened by conn_manager) is closed on context exit
+                await asyncio.sleep(retry_delay)
                 retry_delay *= 2
-                continue  # Continue to next attempt
+                continue
             logger.error(f"Error on final attempt ({attempts}) for job {job_id}. Raising 500.")
-            # Clean up connection if open
-            if conn:
-                try:
-                    db.db.close()
-                except Exception as close_err:
-                    logger.warning(
-                        f"Error closing connection during final error handling: {close_err}",
-                    )
             raise HTTPException(
                 status_code=500,
                 detail=f"Database error after retries: {e!s}",
             )
-
-        finally:
-            # Make sure to close the connection if it's still open *at the end of this attempt*
-            if conn:
-                db.db.close()
+        # The 'finally' block for closing 'conn' is removed as conn_manager handles it.
 
     # If the loop finished without finding the job (i.e., break was hit after max attempts)
     # raise the 404 error.

--- a/src/web_service/main.py
+++ b/src/web_service/main.py
@@ -14,7 +14,7 @@ from src.common.config import (
     check_config,
 )
 from src.common.logger import get_logger
-from src.lib.database import Database
+from src.lib.database import DatabaseOperations
 from src.web_service.api import api_router
 
 # Get logger for this module
@@ -35,9 +35,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     """
     # Initialize databases in read-only mode for the web service
-    db = Database(read_only=True)
-    db.initialize()
-    db.close()
+    db = DatabaseOperations(read_only=True)
+    db.db.initialize()
+    db.db.close()
     logger.info("Database initialization complete")
     if not check_config():
         logger.error("Invalid configuration. Exiting.")

--- a/src/web_service/main.py
+++ b/src/web_service/main.py
@@ -34,10 +34,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         None: Indicates the application is ready.
 
     """
-    # Initialize databases in read-only mode for the web service
-    db = DatabaseOperations(read_only=True)
-    db.db.initialize()
-    db.db.close()
+    # Initialize databases for the web service
+    DatabaseOperations()
+    # The db.db.initialize() is called within DatabaseOperations constructor using a context manager.
+    # The db.db.close() is also handled by the context manager in initialize.
     logger.info("Database initialization complete")
     if not check_config():
         logger.error("Invalid configuration. Exiting.")

--- a/src/web_service/services/debug_bm25.py
+++ b/src/web_service/services/debug_bm25.py
@@ -9,17 +9,10 @@ logger = get_logger(__name__)
 
 
 async def debug_bm25_search(conn: duckdb.DuckDBPyConnection, query: str) -> dict:
-    """Diagnose BM25 search issues by executing tests and gathering debug information.
-
-    Args:
-        conn: Connected DuckDB connection
-        query: Search query to test
-
-    Returns:
-        dict: Diagnostic information
-
+    """Diagnose BM25/FTS search issues by always attempting to query the FTS index using DuckDB's FTS extension.
+    Reports the result of the FTS query attempt, any errors, and explains FTS index visibility.
     """
-    logger.info(f"Running BM25 search diagnostics for query: '{query}'")
+    logger.info(f"Running BM25/FTS search diagnostics for query: '{query}' (DuckDB-specific)")
     results = {}
 
     try:
@@ -31,97 +24,67 @@ async def debug_bm25_search(conn: duckdb.DuckDBPyConnection, query: str) -> dict
         results["fts_extension_loaded"] = bool(fts_loaded)
         logger.info(f"FTS extension loaded: {results['fts_extension_loaded']}")
 
-        # Check for FTS tables
-        fts_tables = conn.execute("""
-        SELECT table_name FROM information_schema.tables
-        WHERE table_name LIKE 'fts%'
-        """).fetchall()
-        results["fts_tables"] = [row[0] for row in fts_tables]
-        logger.info(f"FTS tables: {results['fts_tables']}")
-
         # Count records in pages table
-        pages_count = conn.execute("SELECT COUNT(*) FROM pages").fetchone()[0]
-        results["pages_count"] = pages_count
-        logger.info(f"Pages table record count: {pages_count}")
-
-        # Test direct access to the fts_main_pages table
         try:
-            fts_count = conn.execute("SELECT COUNT(*) FROM fts_main_pages").fetchone()[0]
-            results["fts_main_pages_count"] = fts_count
-            logger.info(f"FTS table record count: {fts_count}")
-
-            if fts_count > 0:
-                # Sample a record to see what's in the FTS table
-                sample = conn.execute("""
-                SELECT id, substr(raw_text, 1, 100) as sample
-                FROM fts_main_pages LIMIT 1
-                """).fetchone()
-                if sample:
-                    results["fts_sample"] = {"id": sample[0], "text_sample": sample[1] + "..."}
-                    logger.info(f"FTS sample record: ID={sample[0]}, Text={sample[1]}...")
+            pages_count = conn.execute("SELECT COUNT(*) FROM pages").fetchone()[0]
+            results["pages_count"] = pages_count
+            logger.info(f"Pages table record count: {pages_count}")
         except Exception as e:
-            results["fts_main_pages_access"] = {"success": False, "error": str(e)}
-            logger.warning(f"Could not access fts_main_pages table: {e}")
+            results["pages_count"] = None
+            results["pages_count_error"] = str(e)
+            logger.warning(f"Could not count pages: {e}")
 
-        # Try direct BM25 search
+        # Always attempt FTS/BM25 search using DuckDB FTS extension
         try:
-            # Skip the namespace/function lookup that's causing errors
-            namespace = "fts_main_pages"  # Use the known namespace
             escaped_query = query.replace("'", "''")
-
-            direct_sql = f"""
-            SELECT p.id, p.url, {namespace}.match_bm25(p.id, '{escaped_query}') AS score
+            bm25_sql = f"""
+            SELECT p.id, p.url, fts_main_pages.match_bm25(p.id, '{escaped_query}') AS score
             FROM pages p
             WHERE score IS NOT NULL
             ORDER BY score DESC
             LIMIT 5
             """
-
-            results["bm25_sql"] = direct_sql
-            logger.info(f"Executing direct BM25 search: {direct_sql}")
-
-            bm25_results = conn.execute(direct_sql).fetchall()
-
-            results["direct_bm25_search"] = {
+            logger.info(f"Attempting FTS/BM25 search: {bm25_sql}")
+            bm25_results = conn.execute(bm25_sql).fetchall()
+            results["fts_bm25_search"] = {
                 "success": True,
                 "count": len(bm25_results),
                 "samples": [
                     {"id": row[0], "url": row[1], "score": row[2]} for row in bm25_results[:3]
-                ],  # Include up to 3 samples
+                ],
+                "error": None,
             }
-            logger.info(f"Direct BM25 search results: {len(bm25_results)}")
-        except Exception as e:
-            results["direct_bm25_search"] = {"success": False, "error": str(e)}
-            logger.warning(f"Direct BM25 search failed: {e}")
+            logger.info(f"FTS/BM25 search returned {len(bm25_results)} results")
+        except Exception as e_bm25:
+            results["fts_bm25_search"] = {
+                "success": False,
+                "count": 0,
+                "samples": [],
+                "error": str(e_bm25),
+            }
+            logger.warning(f"FTS/BM25 search failed: {e_bm25}")
 
-        # Try fallback simple text search
+        # Add a note about FTS index visibility in DuckDB
+        results["fts_index_visibility_note"] = (
+            "DuckDB FTS indexes are not visible in sqlite_master or information_schema.tables. "
+            "If FTS index creation returned an 'already exists' error, the index is present and can be queried "
+            "using fts_main_<table>.match_bm25 or similar functions, even if not listed in system tables."
+        )
+
+        # Add table/column info for clarity
         try:
-            escaped_query = query.replace("'", "''")
-            simple_sql = f"""
-            SELECT id, url, substr(raw_text, 1, 100) as text_sample
-            FROM pages
-            WHERE raw_text LIKE '%{escaped_query}%'
-            LIMIT 5
-            """
-
-            logger.info(f"Executing simple text search: {simple_sql}")
-            simple_results = conn.execute(simple_sql).fetchall()
-
-            results["simple_text_search"] = {
-                "success": True,
-                "count": len(simple_results),
-                "samples": [
-                    {"id": row[0], "url": row[1], "text_sample": row[2]}
-                    for row in simple_results[:3]
-                ],  # Include up to 3 samples
-            }
-            logger.info(f"Simple text search results: {len(simple_results)}")
-        except Exception as e:
-            results["simple_text_search"] = {"success": False, "error": str(e)}
-            logger.warning(f"Simple text search failed: {e}")
+            tables = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+            table_names = [row[0] for row in tables]
+            results["tables"] = table_names
+            if "pages" in table_names:
+                columns = conn.execute("PRAGMA table_info('pages')").fetchall()
+                col_names = [row[1] for row in columns]
+                results["pages_columns"] = col_names
+        except Exception as e_schema:
+            results["schema_check_error"] = str(e_schema)
 
     except Exception as e:
-        logger.error(f"BM25 diagnostics failed: {e}")
+        logger.error(f"BM25/FTS diagnostics failed: {e}")
         results["error"] = str(e)
 
     return results

--- a/src/web_service/services/job_service.py
+++ b/src/web_service/services/job_service.py
@@ -150,12 +150,12 @@ async def get_job_count() -> int:
         int: Total number of jobs
 
     """
-    from src.lib.database import Database
+    from src.lib.database import DatabaseOperations
 
     db = None
     try:
-        db = Database(read_only=True)
-        conn = db.connect()
+        db = DatabaseOperations(read_only=True)
+        conn = db.db.ensure_connection()
         job_count = conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0]
         logger.info(f"Database contains {job_count} total jobs.")
         return job_count
@@ -164,4 +164,4 @@ async def get_job_count() -> int:
         return -1
     finally:
         if db:
-            db.close()
+            db.db.close()

--- a/src/web_service/services/job_service.py
+++ b/src/web_service/services/job_service.py
@@ -152,16 +152,22 @@ async def get_job_count() -> int:
     """
     from src.lib.database import DatabaseOperations
 
-    db = None
+    db_ops = DatabaseOperations()
     try:
-        db = DatabaseOperations(read_only=True)
-        conn = db.db.ensure_connection()
-        job_count = conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0]
-        logger.info(f"Database contains {job_count} total jobs.")
-        return job_count
+        # Use DuckDBConnectionManager as a context manager
+        with db_ops.db as conn_manager:
+            actual_conn = conn_manager.conn
+            if not actual_conn:
+                logger.error("Failed to obtain database connection for get_job_count.")
+                return -1  # Or raise an error
+            job_count_result = actual_conn.execute("SELECT COUNT(*) FROM jobs").fetchone()
+            if job_count_result:
+                job_count = job_count_result[0]
+                logger.info(f"Database contains {job_count} total jobs.")
+                return job_count
+            logger.warning("Could not retrieve job count from database.")
+            return -1
     except Exception as count_error:
         logger.warning(f"Failed to count jobs in database: {count_error!s}")
         return -1
-    finally:
-        if db:
-            db.db.close()
+    # No finally block needed to close connection, context manager handles it.

--- a/tests/api/test_documents_api.py
+++ b/tests/api/test_documents_api.py
@@ -54,12 +54,14 @@ def test_search_docs_endpoint(test_client, mock_duckdb_connection):
     )
 
     # Mock the search_docs service function and DuckDB connection
+    mock_db_class = MagicMock()
+    mock_db_instance = MagicMock()
+    mock_db_instance.conn = mock_duckdb_connection
+    mock_db_class.return_value = mock_db_instance
+
     with (
         patch("src.web_service.api.documents.search_docs", return_value=mock_results),
-        patch(
-            "src.web_service.api.documents.Database.connect_with_retry",
-            return_value=mock_duckdb_connection,
-        ),
+        patch("src.web_service.api.documents.DatabaseOperations", return_value=mock_db_class),
     ):
         # Call the API endpoint
         response = test_client.get(
@@ -85,12 +87,14 @@ def test_search_docs_endpoint(test_client, mock_duckdb_connection):
 def test_search_docs_endpoint_error(test_client, mock_duckdb_connection):
     """Test error handling in the search_docs endpoint."""
     # Mock an exception in the search_docs service function
+    mock_db_class = MagicMock()
+    mock_db_instance = MagicMock()
+    mock_db_instance.conn = mock_duckdb_connection
+    mock_db_class.return_value = mock_db_instance
+
     with (
         patch("src.web_service.api.documents.search_docs", side_effect=Exception("Database error")),
-        patch(
-            "src.web_service.api.documents.Database.connect_with_retry",
-            return_value=mock_duckdb_connection,
-        ),
+        patch("src.web_service.api.documents.DatabaseOperations", return_value=mock_db_class),
     ):
         # Call the API endpoint
         response = test_client.get(
@@ -132,12 +136,14 @@ def test_list_doc_pages_endpoint(test_client, mock_duckdb_connection):
     )
 
     # Mock the list_doc_pages service function and DuckDB connection
+    mock_db_class = MagicMock()
+    mock_db_instance = MagicMock()
+    mock_db_instance.conn = mock_duckdb_connection
+    mock_db_class.return_value = mock_db_instance
+
     with (
         patch("src.web_service.api.documents.list_doc_pages", return_value=mock_response),
-        patch(
-            "src.web_service.api.documents.Database.connect_with_retry",
-            return_value=mock_duckdb_connection,
-        ),
+        patch("src.web_service.api.documents.DatabaseOperations", return_value=mock_db_class),
     ):
         # Call the API endpoint
         response = test_client.get("/list_doc_pages", params={"page": 1})
@@ -163,12 +169,14 @@ def test_get_doc_page_endpoint(test_client, mock_duckdb_connection):
     )
 
     # Mock the get_doc_page service function and DuckDB connection
+    mock_db_class = MagicMock()
+    mock_db_instance = MagicMock()
+    mock_db_instance.conn = mock_duckdb_connection
+    mock_db_class.return_value = mock_db_instance
+
     with (
         patch("src.web_service.api.documents.get_doc_page", return_value=mock_response),
-        patch(
-            "src.web_service.api.documents.Database.connect_with_retry",
-            return_value=mock_duckdb_connection,
-        ),
+        patch("src.web_service.api.documents.DatabaseOperations", return_value=mock_db_class),
     ):
         # Call the API endpoint
         response = test_client.get(
@@ -189,12 +197,14 @@ def test_get_doc_page_endpoint(test_client, mock_duckdb_connection):
 def test_get_doc_page_endpoint_not_found(test_client, mock_duckdb_connection):
     """Test the get_doc_page endpoint when page is not found."""
     # Mock the get_doc_page service function to return None (page not found)
+    mock_db_class = MagicMock()
+    mock_db_instance = MagicMock()
+    mock_db_instance.conn = mock_duckdb_connection
+    mock_db_class.return_value = mock_db_instance
+
     with (
         patch("src.web_service.api.documents.get_doc_page", return_value=None),
-        patch(
-            "src.web_service.api.documents.Database.connect_with_retry",
-            return_value=mock_duckdb_connection,
-        ),
+        patch("src.web_service.api.documents.DatabaseOperations", return_value=mock_db_class),
     ):
         # Call the API endpoint
         response = test_client.get(
@@ -214,12 +224,14 @@ def test_list_tags_endpoint(test_client, mock_duckdb_connection):
     mock_response = ListTagsResponse(tags=["tag1", "tag2", "tag3"])
 
     # Mock the list_tags service function and DuckDB connection
+    mock_db_class = MagicMock()
+    mock_db_instance = MagicMock()
+    mock_db_instance.conn = mock_duckdb_connection
+    mock_db_class.return_value = mock_db_instance
+
     with (
         patch("src.web_service.api.documents.list_tags", return_value=mock_response),
-        patch(
-            "src.web_service.api.documents.Database.connect_with_retry",
-            return_value=mock_duckdb_connection,
-        ),
+        patch("src.web_service.api.documents.DatabaseOperations", return_value=mock_db_class),
     ):
         # Call the API endpoint
         response = test_client.get("/list_tags")
@@ -278,15 +290,17 @@ def test_document_api_integration(test_client, mock_duckdb_connection):
     tags = ListTagsResponse(tags=["tag1", "tag2"])
 
     # Patch all service functions to return mock data
+    mock_db_class = MagicMock()
+    mock_db_instance = MagicMock()
+    mock_db_instance.conn = mock_duckdb_connection
+    mock_db_class.return_value = mock_db_instance
+
     with (
         patch("src.web_service.api.documents.search_docs", return_value=search_results),
         patch("src.web_service.api.documents.list_doc_pages", return_value=doc_pages),
         patch("src.web_service.api.documents.get_doc_page", return_value=doc_page),
         patch("src.web_service.api.documents.list_tags", return_value=tags),
-        patch(
-            "src.web_service.api.documents.Database.connect_with_retry",
-            return_value=mock_duckdb_connection,
-        ),
+        patch("src.web_service.api.documents.DatabaseOperations", return_value=mock_db_class),
     ):
         # Test search_docs endpoint
         response = test_client.get("/search_docs", params={"query": "test"})

--- a/tests/common/test_indexer.py
+++ b/tests/common/test_indexer.py
@@ -27,7 +27,7 @@ def mock_duckdb_connection():
 def test_vector_indexer_initialization(mock_duckdb_connection):
     """Test VectorIndexer initialization."""
     # Test with default table name
-    with patch("src.lib.database.Database.connect", return_value=mock_duckdb_connection):
+    with patch("src.common.indexer.duckdb.connect", return_value=mock_duckdb_connection):
         indexer = VectorIndexer()
 
         # Check that the connection was retrieved
@@ -37,7 +37,7 @@ def test_vector_indexer_initialization(mock_duckdb_connection):
         mock_duckdb_connection.execute.assert_called_with("LOAD vss;")
 
     # Test with custom table name
-    with patch("src.lib.database.Database.connect", return_value=mock_duckdb_connection):
+    with patch("src.common.indexer.duckdb.connect", return_value=mock_duckdb_connection):
         mock_duckdb_connection.execute.reset_mock()
         indexer = VectorIndexer(table_name="custom_table")
 
@@ -64,7 +64,7 @@ async def test_index_vector(mock_duckdb_connection):
     sample_embedding = [0.1] * VECTOR_SIZE
 
     with (
-        patch("src.lib.database.Database.connect", return_value=mock_duckdb_connection),
+        patch("src.common.indexer.duckdb.connect", return_value=mock_duckdb_connection),
         patch(
             "src.common.indexer.uuid.uuid4",
             return_value=uuid.UUID("12345678-1234-5678-1234-567812345678"),
@@ -154,7 +154,10 @@ async def test_index_vector_error_handling(mock_duckdb_connection):
     """Test error handling when indexing a vector."""
     sample_embedding = [0.1] * VECTOR_SIZE
 
-    with patch("src.lib.database.Database.connect", return_value=mock_duckdb_connection):
+    with patch("src.common.indexer.DatabaseOperations") as mock_db_class:
+        mock_db_instance = MagicMock()
+        mock_db_instance.db.ensure_connection.return_value = mock_duckdb_connection
+        mock_db_class.return_value = mock_db_instance
         # First load VSS in init, then handle table check, then simulate error on INSERT
         mock_duckdb_connection.execute.side_effect = [
             None,  # LOAD vss in __init__
@@ -176,7 +179,7 @@ async def test_index_batch(mock_duckdb_connection):
     sample_embedding = [0.1] * VECTOR_SIZE
 
     with (
-        patch("src.lib.database.Database.connect", return_value=mock_duckdb_connection),
+        patch("src.common.indexer.duckdb.connect", return_value=mock_duckdb_connection),
         patch(
             "src.common.indexer.uuid.uuid4",
             side_effect=[
@@ -402,7 +405,10 @@ async def test_search(mock_duckdb_connection):
         ),
     ]
 
-    with patch("src.lib.database.Database.connect", return_value=mock_duckdb_connection):
+    with patch("src.common.indexer.DatabaseOperations") as mock_db_class:
+        mock_db_instance = MagicMock()
+        mock_db_instance.db.ensure_connection.return_value = mock_duckdb_connection
+        mock_db_class.return_value = mock_db_instance
         # Set up mock response for search query
         mock_cursor = MagicMock()
         mock_cursor.fetchall.return_value = mock_search_results
@@ -470,7 +476,10 @@ async def test_search_error_handling(mock_duckdb_connection):
     """Test error handling when searching for vectors."""
     query_vector = [0.1] * VECTOR_SIZE
 
-    with patch("src.lib.database.Database.connect", return_value=mock_duckdb_connection):
+    with patch("src.common.indexer.DatabaseOperations") as mock_db_class:
+        mock_db_instance = MagicMock()
+        mock_db_instance.db.ensure_connection.return_value = mock_duckdb_connection
+        mock_db_class.return_value = mock_db_instance
         # First handle the LOAD vss; call, then handle table check, then simulate an error on search
         mock_duckdb_connection.execute.side_effect = [
             None,  # LOAD vss in __init__

--- a/tests/common/test_processor.py
+++ b/tests/common/test_processor.py
@@ -13,14 +13,14 @@ def mock_processor_dependencies():
     extract_page_text_mock = MagicMock()
     extract_page_text_mock.return_value = "Extracted text content"
 
-    # Mock for Database class store_page method
+    # Mock for DatabaseOperations class store_page method
     store_page_mock = AsyncMock()
     store_page_mock.return_value = "test-page-123"
 
-    # Mock for Database class update_job_status method
+    # Mock for DatabaseOperations class update_job_status method
     update_job_status_mock = MagicMock()
 
-    # Create a Database class mock that can be both used directly
+    # Create a DatabaseOperations class mock that can be both used directly
     # and as a context manager
     database_mock = MagicMock(
         __enter__=lambda self: self,
@@ -68,7 +68,7 @@ async def test_process_crawl_result(
             mock_processor_dependencies["extract_page_text"],
         ),
         patch(
-            "src.common.processor.Database",
+            "src.common.processor.DatabaseOperations",
             return_value=mock_processor_dependencies["database"],
         ),
         patch("src.common.processor.TextChunker", mock_processor_dependencies["TextChunker"]),
@@ -116,7 +116,7 @@ async def test_process_crawl_result_with_errors(
             mock_processor_dependencies["extract_page_text"],
         ),
         patch(
-            "src.common.processor.Database",
+            "src.common.processor.DatabaseOperations",
             return_value=mock_processor_dependencies["database"],
         ),
         patch("src.common.processor.TextChunker", mock_processor_dependencies["TextChunker"]),
@@ -148,7 +148,7 @@ async def test_process_page_batch(mock_processor_dependencies):
     with (
         patch("src.common.processor.process_crawl_result", mock_process_result),
         patch(
-            "src.common.processor.Database",
+            "src.common.processor.DatabaseOperations",
             return_value=mock_processor_dependencies["database"],
         ),
     ):
@@ -184,7 +184,7 @@ async def test_process_page_batch_with_errors(mock_processor_dependencies):
     with (
         patch("src.common.processor.process_crawl_result", mock_process_result),
         patch(
-            "src.common.processor.Database",
+            "src.common.processor.DatabaseOperations",
             return_value=mock_processor_dependencies["database"],
         ),
     ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,19 +114,19 @@ def in_memory_duckdb_connection():
             # Use the connection for testing
             ...
     """
-    from src.lib.database import Database
+    from src.lib.database import DatabaseOperations
 
     # Create in-memory connection
     conn = duckdb.connect(":memory:")
 
     try:
         # Use the Database class to set up the connection
-        db = Database()
+        db = DatabaseOperations()
         db.conn = conn
 
         # Create tables and set up VSS extension
-        db.ensure_tables()
-        db.ensure_vss_extension()
+        db.db.ensure_tables()
+        db.db.ensure_vss_extension()
 
         yield conn
     finally:
@@ -143,15 +143,15 @@ def ensure_duckdb_database():
     import os
 
     from src.common.config import DUCKDB_PATH
-    from src.lib.database import Database
+    from src.lib.database import DatabaseOperations
 
     # Only initialize if the file doesn't exist
     if not os.path.exists(DUCKDB_PATH):
         print(f"Database file {DUCKDB_PATH} does not exist. Creating it for tests...")
         try:
-            db = Database(read_only=False)
-            db.initialize()
-            db.close()
+            db = DatabaseOperations(read_only=False)
+            db.db.initialize()
+            db.db.close()
             print(f"Successfully created database at {DUCKDB_PATH}")
         except Exception as e:
             print(f"Warning: Failed to create database: {e}")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,18 +15,18 @@ def in_memory_duckdb_connection():
     - HNSW index created
     - pages table created (for document service tests)
     """
-    from src.lib.database import Database
+    from src.lib.database import DatabaseOperations
 
     conn = duckdb.connect(":memory:")
 
     # Use the same setup functions as the main application
     try:
         # Create a Database instance and initialize with our in-memory connection
-        db = Database()
-        db.conn = conn
+        db = DatabaseOperations()
+        db.db.conn = conn
 
         # Initialize all tables and extensions
-        db.initialize()
+        db.db.initialize()
 
         yield conn
     finally:

--- a/tests/services/test_job_service.py
+++ b/tests/services/test_job_service.py
@@ -249,14 +249,12 @@ async def test_get_job_count_error():
     """Test getting job count when an error occurs."""
     # Mock database connection with an error
     mock_conn = MagicMock()
-    mock_conn.execute.side_effect = Exception("Database error")
+    mock_conn.execute.side_effect = duckdb.Error("Database error")
 
     with patch("src.web_service.services.job_service.duckdb.connect", return_value=mock_conn):
-        # Call the function
-        result = await get_job_count()
+        # Call the function and assert duckdb.Error is raised
+        with pytest.raises(duckdb.Error, match="Database error"):
+            await get_job_count()
 
         # Should still close the database even with an error
         # In new implementation, we close the database, not the connection directly
-
-        # Should return -1 to indicate an error
-        assert result == -1

--- a/tests/services/test_job_service.py
+++ b/tests/services/test_job_service.py
@@ -232,7 +232,7 @@ async def test_get_job_count():
     mock_conn = MagicMock()
     mock_conn.execute.return_value.fetchone.return_value = (42,)
 
-    with patch("src.lib.database.Database.connect", return_value=mock_conn):
+    with patch("src.web_service.services.job_service.duckdb.connect", return_value=mock_conn):
         # Call the function
         result = await get_job_count()
 
@@ -251,7 +251,7 @@ async def test_get_job_count_error():
     mock_conn = MagicMock()
     mock_conn.execute.side_effect = Exception("Database error")
 
-    with patch("src.lib.database.Database.connect", return_value=mock_conn):
+    with patch("src.web_service.services.job_service.duckdb.connect", return_value=mock_conn):
         # Call the function
         result = await get_job_count()
 


### PR DESCRIPTION
This PR introduces a full, working version of the BM25 full-text search, improving the relevance and robustness of search results in the `/search_docs` endpoint.

The search endpoint now combines vector (semantic) search and BM25 (full text) to deliver the results that combine semantically relevant results, but also results that are good string matches.

The hybrid weights and the fine-tuning of the search will be continuously iterated on in the future.

### Other Changes
- Database improvements around concurrency; no more read-only v. read-write modes
- Better handling of DuckDB connections

> [!WARNING]
> You will need to re-create your database `doctor.duckdb`. So if you have a working list of docs and need them asap, don't use this version yet.